### PR TITLE
Fix bind return value

### DIFF
--- a/src/serversocket/ServerSocket.cpp
+++ b/src/serversocket/ServerSocket.cpp
@@ -238,6 +238,7 @@ namespace kt
     void ServerSocket::close()
     {
         kt::close(this->socketDescriptor);
+        this->socketDescriptor = getInvalidSocketValue();
     }
 
 } // End namespace kt

--- a/src/socket/Socket.cpp
+++ b/src/socket/Socket.cpp
@@ -43,6 +43,11 @@ namespace kt
 	 */
 	int pollSocket(const SOCKET& socketDescriptor, const long& timeout, timeval* timeOutVal)
 	{
+		if (kt::isInvalidSocket(socketDescriptor))
+		{
+			return -1;
+		}
+
 		fd_set sReady{};
 		timeval timeoutVal{};
 		if (timeOutVal == nullptr)

--- a/src/socket/TCPSocket.cpp
+++ b/src/socket/TCPSocket.cpp
@@ -107,7 +107,6 @@ namespace kt
 			}
 
 			this->close();
-			this->socketDescriptor = getInvalidSocketValue();
 		}
 		
 		throw kt::SocketException("Unable to connect to resolved addresses for provided hostname [" + this->hostname + ":" + std::to_string(this->port) + "] " + getErrorCode());
@@ -121,9 +120,10 @@ namespace kt
 		return res;
 	}
 
-	void TCPSocket::close() const
+	void TCPSocket::close()
 	{
 		kt::close(this->socketDescriptor);
+		this->socketDescriptor = getInvalidSocketValue();
 	}
 
 	bool TCPSocket::ready(const unsigned long timeout) const

--- a/src/socket/TCPSocket.h
+++ b/src/socket/TCPSocket.h
@@ -57,7 +57,7 @@ namespace kt
 			TCPSocket(const kt::TCPSocket&);
 			kt::TCPSocket& operator=(const kt::TCPSocket&);
 			
-			void close() const;
+			void close();
 			
 			int pollSocket(SOCKET socket, const long& = 100) const;
 			bool ready(const unsigned long = 100) const;

--- a/src/socket/UDPSocket.cpp
+++ b/src/socket/UDPSocket.cpp
@@ -37,11 +37,11 @@ namespace kt
 	 * The socket that is listening for new connections will need to call this before they begin listening (accepting connections).
 	 * This ensures the socket is bound to the port and can receive new connections. *Only a single process can be bound to a single port at one time*.
 	 *
-	 * @return bool - true if the socket was bound successfully, otherwise false
+	 * @return the int result of the call to bind(), if this is -1 then there was an error. Along with the bound address if the result code is not an error.
 	 *
 	 * @throw BindingException - if the socket fails to bind
 	 */
-	std::pair<bool, kt::SocketAddress> kt::UDPSocket::bind(const std::optional<std::string>& localHostname, const unsigned short& port, const kt::InternetProtocolVersion protocolVersion, const std::optional<std::function<void(SOCKET&)>>& preBindSocketOperation)
+	std::pair<int, kt::SocketAddress> kt::UDPSocket::bind(const std::optional<std::string>& localHostname, const unsigned short& port, const kt::InternetProtocolVersion protocolVersion, const std::optional<std::function<void(SOCKET&)>>& preBindSocketOperation)
 	{
 		if (this->isUdpBound())
 		{
@@ -93,7 +93,7 @@ namespace kt
 		this->bound = bindResult != -1;
 		if (!this->bound)
 		{
-			throw kt::BindingException("Error binding connection, the port " + std::to_string(port) + " is already being used. Response code from ::bind()" + std::to_string(bindResult) + ". Latest Error code: " + getErrorCode());
+			return std::make_pair(bindResult, kt::SocketAddress{});
 		}
 
 		if (port == 0)
@@ -106,12 +106,13 @@ namespace kt
 			this->listeningPort = std::make_optional(port);
 		}
 
-		return std::make_pair(this->bound, firstAddress);
+		return std::make_pair(bindResult, firstAddress);
 	}
 
 	void UDPSocket::close()
 	{
-		this->close(this->receiveSocket);
+		kt::close(this->receiveSocket);
+		this->receiveSocket = kt::getInvalidSocketValue();
 		
 		this->bound = false;
 		this->listeningPort = std::nullopt;
@@ -251,11 +252,5 @@ namespace kt
 
 		this->listeningPort = std::make_optional(kt::getPortNumber(address.first.value()));
 	}
-
-	void UDPSocket::close(SOCKET socket)
-	{
-		kt::close(socket);
-	}
-	
 }
 

--- a/src/socket/UDPSocket.cpp
+++ b/src/socket/UDPSocket.cpp
@@ -144,7 +144,7 @@ namespace kt
 		}
 
 		int result = ::sendto(tempSocket, buffer, bufferLength, flags, &(address.address), sizeof(address));
-		this->close(tempSocket);
+		kt::close(tempSocket);
 		return result;
 	}
 

--- a/src/socket/UDPSocket.h
+++ b/src/socket/UDPSocket.h
@@ -50,14 +50,13 @@ namespace kt
 
 		int pollSocket(SOCKET socket, const long& = 1000) const;
 		void initialiseListeningPortNumber();
-		void close(SOCKET socket);
 
 	public:
 		UDPSocket() = default;
 		UDPSocket(const kt::UDPSocket&);
 		kt::UDPSocket& operator=(const kt::UDPSocket&);
 
-		std::pair<bool, kt::SocketAddress> bind(const std::optional<std::string>& = std::nullopt, const unsigned short& = 0, const kt::InternetProtocolVersion = kt::InternetProtocolVersion::Any, const std::optional<std::function<void(SOCKET&)>>& = std::nullopt);
+		std::pair<int, kt::SocketAddress> bind(const std::optional<std::string>& = std::nullopt, const unsigned short& = 0, const kt::InternetProtocolVersion = kt::InternetProtocolVersion::Any, const std::optional<std::function<void(SOCKET&)>>& = std::nullopt);
 		void close();
 		bool ready(const unsigned long = 100) const;
 

--- a/tests/socket/ScenarioTest.cpp
+++ b/tests/socket/ScenarioTest.cpp
@@ -14,8 +14,8 @@ namespace kt
     TEST(ScenarioTest, UDPThenTCPBindSamePort)
     {
         kt::UDPSocket socket;
-        std::pair<bool, kt::SocketAddress> bindResult = socket.bind();
-        ASSERT_TRUE(bindResult.first);
+        std::pair<int, kt::SocketAddress> bindResult = socket.bind();
+        ASSERT_EQ(0, bindResult.first);
         ASSERT_NE(std::nullopt, socket.getListeningPort());
 
         kt::ServerSocket server(std::nullopt, socket.getListeningPort().value());
@@ -36,8 +36,8 @@ namespace kt
         kt::ServerSocket server;
 
         kt::UDPSocket socket;
-        std::pair<bool, kt::SocketAddress> bindResult = socket.bind(std::nullopt, server.getPort());
-        ASSERT_TRUE(bindResult.first);
+        std::pair<int, kt::SocketAddress> bindResult = socket.bind(std::nullopt, server.getPort());
+        ASSERT_EQ(0, bindResult.first);
         ASSERT_NE(std::nullopt, socket.getListeningPort());
 
         ASSERT_EQ(server.getPort(), socket.getListeningPort().value());
@@ -57,12 +57,12 @@ namespace kt
         };
 
         kt::UDPSocket socket;
-        std::pair<bool, kt::SocketAddress> bindResult = socket.bind(std::nullopt, 0, kt::InternetProtocolVersion::Any, setReuseAddrOption);
-        ASSERT_TRUE(bindResult.first);
+        std::pair<int, kt::SocketAddress> bindResult = socket.bind(std::nullopt, 0, kt::InternetProtocolVersion::Any, setReuseAddrOption);
+        ASSERT_EQ(0, bindResult.first);
 
         kt::UDPSocket socket2;
         bindResult = socket2.bind(std::nullopt, socket.getListeningPort().value(), kt::InternetProtocolVersion::Any, setReuseAddrOption);
-        ASSERT_TRUE(bindResult.first);
+        ASSERT_EQ(0, bindResult.first);
 
         ASSERT_EQ(socket.getListeningPort().value(), socket2.getListeningPort().value());
 

--- a/tests/socket/TCPSocketTest.cpp
+++ b/tests/socket/TCPSocketTest.cpp
@@ -94,6 +94,10 @@ namespace kt
         ASSERT_EQ(acceptedFromAddress.send(sentFromServer), sentFromServer.size());
         ASSERT_TRUE(fromAddress.ready());
         ASSERT_EQ(sentFromServer, fromAddress.receiveAmount(sentFromServer.size()));
+
+        server.close();
+        fromAddress.close();
+        acceptedFromAddress.close();
     }
 
     // Ensure we throw a SocketException if we cannot construct a TCP socket from the provided SocketAddress
@@ -104,6 +108,8 @@ namespace kt
 
         kt::SocketAddress address{};
         ASSERT_THROW(TCPSocket fromEmptyAddress(address), SocketException);
+
+        server.close();
     }
     
     /*
@@ -360,5 +366,7 @@ namespace kt
 
         std::string recieved = server.receiveAmount(upperBound);
         ASSERT_EQ(message, recieved);
+
+        server.close();
     }
 }

--- a/tests/socket/UDPSocketTest.cpp
+++ b/tests/socket/UDPSocketTest.cpp
@@ -39,7 +39,7 @@ namespace kt
 
     TEST_F(UDPSocketTest, UDPCopyConstructors)
     {
-        ASSERT_TRUE(socket.bind().first);
+        ASSERT_EQ(0, socket.bind().first);
         UDPSocket copiedSocket(socket);
 
         ASSERT_EQ(socket.getListeningSocket(), copiedSocket.getListeningSocket());
@@ -59,14 +59,14 @@ namespace kt
     {
         ASSERT_FALSE(socket.isUdpBound());
         ASSERT_EQ(kt::InternetProtocolVersion::Any, socket.getInternetProtocolVersion());
-        ASSERT_TRUE(socket.bind().first);
+        ASSERT_EQ(0, socket.bind().first);
         ASSERT_NE(kt::InternetProtocolVersion::Any, socket.getInternetProtocolVersion());
         ASSERT_TRUE(socket.isUdpBound());
 
         kt::UDPSocket newServer;
         ASSERT_FALSE(newServer.isUdpBound());
         ASSERT_NE(std::nullopt, socket.getListeningPort());
-        EXPECT_THROW(newServer.bind(std::nullopt, socket.getListeningPort().value()), BindingException);
+        ASSERT_EQ(-1, newServer.bind(std::nullopt, socket.getListeningPort().value()).first);
     }
 
     /*
@@ -75,7 +75,7 @@ namespace kt
     TEST_F(UDPSocketTest, UDPBind_WithoutSpecifiedPort)
     {
         ASSERT_FALSE(socket.isUdpBound());
-        ASSERT_TRUE(socket.bind(std::nullopt, 0).first);
+        ASSERT_EQ(0, socket.bind(std::nullopt, 0).first);
         ASSERT_TRUE(socket.isUdpBound());
         ASSERT_NE(0, socket.getListeningPort());
     }
@@ -85,7 +85,7 @@ namespace kt
      */
     TEST_F(UDPSocketTest, UDPSendTo)
     {
-        ASSERT_TRUE(socket.bind().first);
+        ASSERT_EQ(0, socket.bind().first);
 
         UDPSocket client;
 
@@ -100,7 +100,7 @@ namespace kt
      */
     TEST_F(UDPSocketTest, TestEmptyHostname)
     {
-        ASSERT_TRUE(socket.bind().first);
+        ASSERT_EQ(0, socket.bind().first);
         
         UDPSocket client;
         ASSERT_FALSE(socket.ready());
@@ -123,7 +123,7 @@ namespace kt
      */
     TEST_F(UDPSocketTest, UDPReceiveFrom)
     {
-        ASSERT_TRUE(socket.bind().first);
+        ASSERT_EQ(0, socket.bind().first);
         ASSERT_FALSE(socket.ready());
 
         UDPSocket client;
@@ -143,7 +143,7 @@ namespace kt
      */
     TEST_F(UDPSocketTest, UDPReceiveAmount_NotEnoughRead)
     {
-        ASSERT_TRUE(socket.bind().first);
+        ASSERT_EQ(0, socket.bind().first);
         ASSERT_FALSE(socket.ready());
 
         UDPSocket client;
@@ -162,7 +162,7 @@ namespace kt
      */
     TEST_F(UDPSocketTest, UDPReceiveAmount_TooMuchRead)
     {
-        ASSERT_TRUE(socket.bind().first);
+        ASSERT_EQ(0, socket.bind().first);
         ASSERT_FALSE(socket.ready());
 
         UDPSocket client;
@@ -181,7 +181,7 @@ namespace kt
      */
     TEST_F(UDPSocketTest, UDPSendToAddress)
     {
-        ASSERT_TRUE(socket.bind().first);
+        ASSERT_EQ(0, socket.bind().first);
         ASSERT_FALSE(socket.ready());
 
         UDPSocket client;
@@ -212,10 +212,10 @@ namespace kt
      */
     TEST_F(UDPSocketTest, UDPManipulateAddress_IPV4)
     {
-        ASSERT_TRUE(socket.bind(std::nullopt, 0, kt::InternetProtocolVersion::IPV4).first);
+        ASSERT_EQ(0, socket.bind(std::nullopt, 0, kt::InternetProtocolVersion::IPV4).first);
 
         kt::UDPSocket client;
-        ASSERT_TRUE(client.bind(std::nullopt, 0, kt::InternetProtocolVersion::IPV4).first);
+        ASSERT_EQ(0, client.bind(std::nullopt, 0, kt::InternetProtocolVersion::IPV4).first);
 
         std::string message = std::to_string(client.getListeningPort().value());
         ASSERT_EQ(client.sendTo("127.0.0.1", socket.getListeningPort().value(), message).first, message.size());
@@ -235,10 +235,10 @@ namespace kt
 
     TEST_F(UDPSocketTest, UDPManipulateAddress_IPV6)
     {
-        ASSERT_TRUE(socket.bind(std::nullopt, 0, kt::InternetProtocolVersion::IPV6).first);
+        ASSERT_EQ(0, socket.bind(std::nullopt, 0, kt::InternetProtocolVersion::IPV6).first);
 
         kt::UDPSocket client;
-        ASSERT_TRUE(client.bind(std::nullopt, 0, kt::InternetProtocolVersion::IPV6).first);
+        ASSERT_EQ(0, client.bind(std::nullopt, 0, kt::InternetProtocolVersion::IPV6).first);
 
         std::string message = std::to_string(client.getListeningPort().value());
         ASSERT_EQ(client.sendTo("::1", socket.getListeningPort().value(), message).first, message.size());
@@ -261,8 +261,8 @@ namespace kt
     TEST_F(UDPSocketTest, SendToBoundAddress)
     {
         // Setting IP version here for windows as its seems to be biasing towards different IP versions
-        std::pair<bool, kt::SocketAddress> bindResult = socket.bind(std::nullopt, 0, kt::InternetProtocolVersion::IPV4);
-        ASSERT_TRUE(bindResult.first);
+        std::pair<int, kt::SocketAddress> bindResult = socket.bind(std::nullopt, 0, kt::InternetProtocolVersion::IPV4);
+        ASSERT_EQ(0, bindResult.first);
 
         UDPSocket client;
         ASSERT_FALSE(socket.ready());
@@ -278,8 +278,8 @@ namespace kt
      */
     TEST_F(UDPSocketTest, LargePayloadSend)
     {
-        std::pair<bool, kt::SocketAddress> bindResult = socket.bind(std::nullopt, 0, kt::InternetProtocolVersion::IPV4);
-        ASSERT_TRUE(bindResult.first);
+        std::pair<int, kt::SocketAddress> bindResult = socket.bind(std::nullopt, 0, kt::InternetProtocolVersion::IPV4);
+        ASSERT_EQ(0, bindResult.first);
 
         int receiveBufferSize;
         socklen_t size = sizeof(receiveBufferSize);
@@ -336,8 +336,8 @@ namespace kt
      */
     TEST_F(UDPSocketTest, LargePayloadRecieve_AndPreSendSocketOperation)
     {
-        std::pair<bool, kt::SocketAddress> bindResult = socket.bind(std::nullopt, 0, kt::InternetProtocolVersion::IPV4);
-        ASSERT_TRUE(bindResult.first);
+        std::pair<int, kt::SocketAddress> bindResult = socket.bind(std::nullopt, 0, kt::InternetProtocolVersion::IPV4);
+        ASSERT_EQ(0, bindResult.first);
 
         int receiveBufferSize;
         socklen_t size = sizeof(receiveBufferSize);


### PR DESCRIPTION
- Refactor all socket close() functions to set the descriptor to an invalid descriptor.
- Fix pollSocket() method to not attempt to poll an invalid descriptor.
- Fix bind return function to return the int result from bind() instead of just a bool.
- Update tests