### PR TITLE
Create datagram ipc socket

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ set(HEADERS
         src/address/SocketAddress.h
         src/ipc/StreamIPCSocket.h
         src/ipc/IPCServerSocket.h
+        src/ipc/IPCSocket.h
+        src/ipc/DatagramIPCSocket.h
         src/socketexceptions/BindingException.hpp
         src/socketexceptions/SocketException.hpp
         src/socketexceptions/TimeoutException.hpp
@@ -35,6 +37,8 @@ set(SOURCE
         src/address/SocketAddress.cpp
         src/ipc/StreamIPCSocket.cpp
         src/ipc/IPCServerSocket.cpp
+        src/ipc/IPCSocket.cpp
+        src/ipc/DatagramIPCSocket.cpp
 )
 
 # Project Configuration - Adding as a lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(HEADERS
         src/socket/TCPSocket.h
         src/socket/UDPSocket.h
         src/address/SocketAddress.h
-        src/ipc/IPCSocket.h
+        src/ipc/StreamIPCSocket.h
         src/ipc/IPCServerSocket.h
         src/socketexceptions/BindingException.hpp
         src/socketexceptions/SocketException.hpp
@@ -33,7 +33,7 @@ set(SOURCE
         src/socket/UDPSocket.cpp
         src/socketexceptions/SocketError.cpp
         src/address/SocketAddress.cpp
-        src/ipc/IPCSocket.cpp
+        src/ipc/StreamIPCSocket.cpp
         src/ipc/IPCServerSocket.cpp
 )
 

--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ void udpExample()
 }
 ```
 
-### IPC Example - Very similar to the TCPSocket example
+### Stream IPC Example - Very similar to the TCPSocket example
 
 ```cpp
-void ipcExample()
+void streamIpcExample()
 {
     const std::string ipcChannel = "/tmp/ipcExample.sock";
     // Create a new IPCSocket
@@ -126,6 +126,41 @@ void ipcExample()
     serverSocket.close();
 }
 ```
+
+---
+
+### Datagram IPC Example - Very similar to the UDPSocket example
+
+**DatagramIPCSocket is not supported on Windows**
+
+```cpp
+void datagramIpcExample()
+{
+    const std::string socketPath = "/tmp/my-socket.sock";
+
+    // The socket receiving data must first be bound
+    kt::DatagramIPCSocket socket;
+    socket.bind(socketPath);
+
+    kt::DatagramIPCSocket client;
+    const std::string testString = "UDP test string";
+    if (client.sendTo(socketPath, testString) == 0)
+    {
+        std::cout << "Failed to send." << std::endl;
+        return;
+    }
+
+    if (socket.ready())
+    {
+        std::pair<std::optional<std::string>, std::pair<int, std::string>> recieved = socket.receiveFrom(testString.size());
+        ASSERT_EQ(testString, recieved.first.value());
+    }
+
+    socket.close();
+}
+```
+
+---
 
 ## SIGPIPE Errors
 

--- a/src/ipc/DatagramIPCSocket.cpp
+++ b/src/ipc/DatagramIPCSocket.cpp
@@ -37,7 +37,7 @@ namespace kt
             IPCSocket::removeSocketPath(path);
         }
 
-        receiveSocket = ::socket(AF_UNIX, SOCK_STREAM, 0);
+        receiveSocket = ::socket(AF_UNIX, SOCK_DGRAM, 0);
         if (isInvalidSocket(this->receiveSocket))
         {
             throw kt::SocketException("Error creating IPC server socket: " + getErrorCode());

--- a/src/ipc/DatagramIPCSocket.cpp
+++ b/src/ipc/DatagramIPCSocket.cpp
@@ -1,15 +1,169 @@
 #include "DatagramIPCSocket.h"
 
+#include "../socketexceptions/BindingException.hpp"
+
 namespace kt
 {
+    std::pair<int, std::string> DatagramIPCSocket::bind(const std::optional<std::string> &socketPath, const std::optional<std::function<void(SOCKET &)>> &preBindSocketOperation)
+    {
+        return bind(false, socketPath, preBindSocketOperation);
+    }
+
+    std::pair<int, std::string> DatagramIPCSocket::bind(const bool &override, const std::optional<std::string> &socketPathOpt, const std::optional<std::function<void(SOCKET &)>> &preBindSocketOperation)
+    {
+        if (!socketPathOpt.has_value())
+		{
+			throw kt::BindingException("Failed to bind to empty socket path");
+		}
+        std::string path = socketPathOpt.value();
+
+        sockaddr_un address{};
+        address.sun_family = AF_UNIX;
+
+        if (path.size() >= std::size(address.sun_path))
+        {
+            path.resize(std::size(address.sun_path));
+        }
+
+#ifdef _WIN32
+        strcpy_s(address.sun_path, std::size(address.sun_path), path.c_str());
+#else
+        strncpy(address.sun_path, path.c_str(), std::size(address.sun_path));
+#endif
+
+        // When override is true, attempt to remove any existing socket path file before attempting to bind/create it
+        if (override)
+        {
+            IPCSocket::removeSocketPath(path);
+        }
+
+        receiveSocket = ::socket(AF_UNIX, SOCK_STREAM, 0);
+        if (isInvalidSocket(this->receiveSocket))
+        {
+            throw kt::SocketException("Error creating IPC server socket: " + getErrorCode());
+        }
+
+        if (isBound())
+        {
+            this->close();
+        }
+
+        if (preBindSocketOperation.has_value())
+        {
+            preBindSocketOperation.value()(this->receiveSocket);
+        }
+
+        socklen_t socketSize = sizeof(address);
+        int bindResult = ::bind(this->receiveSocket, (sockaddr*)&address, socketSize);
+		this->bound = bindResult != -1;
+		if (!this->bound)
+		{
+			return std::make_pair(bindResult, "");
+		}
+
+        this->socketPath = path;
+		return std::make_pair(bindResult, socketPath.value());
+    }
+
     bool DatagramIPCSocket::isBound() const
     {
         return bound;
     }
 
+    SOCKET DatagramIPCSocket::getListeningSocket() const
+    {
+        return receiveSocket;
+    }
+
+    std::optional<std::string> DatagramIPCSocket::getSocketPath() const
+    {
+        return socketPath;
+    }
+
     void DatagramIPCSocket::setPreSendSocketOperation(std::function<void(SOCKET &)> preSendSocketOperation)
     {
         this->preSendSocketOperation = preSendSocketOperation;
+    }
+
+    bool DatagramIPCSocket::ready(const unsigned long timeout) const
+    {
+        if (!isBound())
+		{
+			return false;
+		}
+		
+		int result = this->pollSocket(this->receiveSocket, timeout);
+		// 0 indicates that there is no data
+		return result > 0;
+    }
+
+    int DatagramIPCSocket::sendTo(const std::string &path, const std::string &message, const int &flags)
+    {
+        return sendTo(path, message.c_str(), message.size(), flags);
+    }
+
+    int DatagramIPCSocket::sendTo(const std::string &path, const char *buffer, const int &bufferLength, const int &flags)
+    {
+        SOCKET tempSocket = socket(AF_UNIX, SOCK_DGRAM, 0);
+		if (kt::isInvalidSocket(tempSocket))
+		{
+			return -2;
+		}
+
+		if (preSendSocketOperation.has_value())
+		{
+			preSendSocketOperation.value()(tempSocket);
+		}
+
+        sockaddr_un address{};
+        address.sun_family = AF_UNIX;
+
+        std::string sendPath = path;
+        if (sendPath.size() >= std::size(address.sun_path))
+        {
+            sendPath.resize(std::size(address.sun_path));
+        }
+
+#ifdef _WIN32
+        strcpy_s(address.sun_path, std::size(address.sun_path), sendPath.c_str());
+#else
+        strncpy(address.sun_path, sendPath.c_str(), std::size(address.sun_path));
+#endif
+
+		int result = ::sendto(tempSocket, buffer, bufferLength, flags, (sockaddr*)&address, sizeof(address));
+		Socket::close(tempSocket);
+		return result;
+    }
+
+    std::pair<std::optional<std::string>, std::pair<int, std::string>> DatagramIPCSocket::receiveFrom(const int &receiveLength, const int &flags)
+    {
+        std::string data;
+		data.resize(receiveLength);
+
+		std::pair<int, std::string> result = this->receiveFrom(&data[0], receiveLength, flags);
+
+		// Need to substring to remove any null terminating bytes
+		if (result.first >= 0 && result.first < receiveLength)
+		{
+			data = data.substr(0, result.first);
+		}
+
+		return std::make_pair(data.size() == 0 ? std::nullopt : std::make_optional(data), result);
+    }
+
+    std::pair<int, std::string> DatagramIPCSocket::receiveFrom(char *buffer, const int &receiveLength, const int &flags) const
+    {
+		if (!isBound() || receiveLength == 0)
+		{
+			return std::make_pair(-1, "");
+		}
+
+        sockaddr_un receiveAddress{};
+        // Using auto here since the "addressLength" argument for "::recvfrom()" has differing types depending what platform
+		// we are on, so I am letting the definition of kt::getAddressLength() drive this type via auto
+		socklen_t addressLength = sizeof(receiveAddress);
+        int flag = ::recvfrom(this->receiveSocket, buffer, receiveLength, flags, (sockaddr*)&receiveAddress, &addressLength);
+		return std::make_pair(flag, std::string{receiveAddress.sun_path});
     }
 
     void DatagramIPCSocket::close()
@@ -21,7 +175,7 @@ namespace kt
         {
             IPCSocket::removeSocketPath(socketPath.value());
         }
-		
+		socketPath = std::nullopt;
 		this->bound = false;
     }
 }

--- a/src/ipc/DatagramIPCSocket.cpp
+++ b/src/ipc/DatagramIPCSocket.cpp
@@ -1,0 +1,27 @@
+#include "DatagramIPCSocket.h"
+
+namespace kt
+{
+    bool DatagramIPCSocket::isBound() const
+    {
+        return bound;
+    }
+
+    void DatagramIPCSocket::setPreSendSocketOperation(std::function<void(SOCKET &)> preSendSocketOperation)
+    {
+        this->preSendSocketOperation = preSendSocketOperation;
+    }
+
+    void DatagramIPCSocket::close()
+    {
+        Socket::close(this->receiveSocket);
+		this->receiveSocket = kt::getInvalidSocketValue();
+
+        if (isBound() && socketPath.has_value())
+        {
+            IPCSocket::removeSocketPath(socketPath.value());
+        }
+		
+		this->bound = false;
+    }
+}

--- a/src/ipc/DatagramIPCSocket.cpp
+++ b/src/ipc/DatagramIPCSocket.cpp
@@ -4,6 +4,13 @@
 
 namespace kt
 {
+    DatagramIPCSocket::DatagramIPCSocket()
+    {
+#ifdef _WIN32
+        throw SocketException("DatagramIPCSocket is not supported on Windows.");
+#endif
+    }
+
     std::pair<int, std::string> DatagramIPCSocket::bind(const std::optional<std::string> &socketPath, const std::optional<std::function<void(SOCKET &)>> &preBindSocketOperation)
     {
         return bind(false, socketPath, preBindSocketOperation);
@@ -40,7 +47,7 @@ namespace kt
         receiveSocket = ::socket(AF_UNIX, SOCK_DGRAM, 0);
         if (isInvalidSocket(this->receiveSocket))
         {
-            throw kt::SocketException("Error creating IPC server socket: " + getErrorCode());
+            throw kt::SocketException("Error creating binding socket: " + getErrorCode());
         }
 
         if (isBound())
@@ -163,7 +170,9 @@ namespace kt
 		// we are on, so I am letting the definition of kt::getAddressLength() drive this type via auto
 		socklen_t addressLength = sizeof(receiveAddress);
         int flag = ::recvfrom(this->receiveSocket, buffer, receiveLength, flags, (sockaddr*)&receiveAddress, &addressLength);
-		return std::make_pair(flag, std::string{receiveAddress.sun_path});
+
+        // Just return "socketPath" since we know that messages can only come from that path since we are bound to it
+		return std::make_pair(flag, socketPath.value());
     }
 
     void DatagramIPCSocket::close()

--- a/src/ipc/DatagramIPCSocket.h
+++ b/src/ipc/DatagramIPCSocket.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "../socket/ConnectionLessSocket.h"
+#include "IPCSocket.h"
+#include "../socketexceptions/SocketError.h"
+
+#ifdef _WIN32
+
+#ifndef WIN32_LEAN_AND_MEAN
+	#define WIN32_LEAN_AND_MEAN
+#endif
+
+#ifndef _WIN32_WINNT
+    #define _WIN32_WINNT 0x0600
+#endif
+
+#include <WinSock2.h>
+#include <ws2tcpip.h>
+#include <afunix.h>
+
+#else
+
+#include <sys/socket.h>
+#include <unistd.h>
+#include <netdb.h>
+#include <sys/un.h>
+
+// Typedef to match the windows typedef since they are different underlying types
+typedef int SOCKET;
+
+#endif
+
+namespace kt
+{
+    class DatagramIPCSocket : ConnectionLessSocket<std::string>, public IPCSocket
+    {
+        private:
+            bool bound = false;
+            std::optional<std::string> socketPath = std::nullopt;
+            SOCKET receiveSocket = getInvalidSocketValue();
+            std::optional<std::function<void(SOCKET&)>> preSendSocketOperation = std::nullopt;
+
+        public:
+            DatagramIPCSocket() = default;
+
+            using ConnectionLessSocket::bind;
+            std::pair<int, std::string> bind(const std::optional<std::string>& = std::nullopt, const std::optional<std::function<void(SOCKET&)>>& = std::nullopt) override;
+            bool isBound() const override;
+
+            void setPreSendSocketOperation(std::function<void(SOCKET&)>);
+
+		    void close() override;
+    };
+}

--- a/src/ipc/DatagramIPCSocket.h
+++ b/src/ipc/DatagramIPCSocket.h
@@ -45,9 +45,21 @@ namespace kt
 
             using ConnectionLessSocket::bind;
             std::pair<int, std::string> bind(const std::optional<std::string>& = std::nullopt, const std::optional<std::function<void(SOCKET&)>>& = std::nullopt) override;
+            std::pair<int, std::string> bind(const bool&, const std::optional<std::string>& = std::nullopt, const std::optional<std::function<void(SOCKET&)>>& = std::nullopt);
             bool isBound() const override;
 
+            SOCKET getListeningSocket() const;
+            std::optional<std::string> getSocketPath() const;
+
             void setPreSendSocketOperation(std::function<void(SOCKET&)>);
+
+            bool ready(const unsigned long = 100) const override;
+
+            int sendTo(const std::string&, const std::string&, const int& = 0) override;
+            int sendTo(const std::string&, const char*, const int&, const int& = 0) override;
+            
+            std::pair<std::optional<std::string>, std::pair<int, std::string>> receiveFrom(const int&, const int& = 0) override;
+            std::pair<int, std::string> receiveFrom(char*, const int&, const int& = 0) const override;
 
 		    void close() override;
     };

--- a/src/ipc/DatagramIPCSocket.h
+++ b/src/ipc/DatagramIPCSocket.h
@@ -41,7 +41,7 @@ namespace kt
             std::optional<std::function<void(SOCKET&)>> preSendSocketOperation = std::nullopt;
 
         public:
-            DatagramIPCSocket() = default;
+            DatagramIPCSocket();
 
             using ConnectionLessSocket::bind;
             std::pair<int, std::string> bind(const std::optional<std::string>& = std::nullopt, const std::optional<std::function<void(SOCKET&)>>& = std::nullopt) override;

--- a/src/ipc/IPCServerSocket.cpp
+++ b/src/ipc/IPCServerSocket.cpp
@@ -56,7 +56,7 @@ namespace kt
         // When override is true, attempt to remove any existing socket path file before attempting to bind/create it
         if (override)
         {
-            StreamIPCSocket::closePath(socketPath.c_str());
+            IPCSocket::removeSocketPath(socketPath);
         }
 
         socket = ::socket(AF_UNIX, SOCK_STREAM, 0);
@@ -113,7 +113,7 @@ namespace kt
     void IPCServerSocket::close()
     {
         Socket::close(socket);
-        StreamIPCSocket::closePath(socketPath);
         socket = kt::getInvalidSocketValue();
+        IPCSocket::removeSocketPath(socketPath);
     }
 }

--- a/src/ipc/IPCServerSocket.cpp
+++ b/src/ipc/IPCServerSocket.cpp
@@ -56,7 +56,7 @@ namespace kt
         // When override is true, attempt to remove any existing socket path file before attempting to bind/create it
         if (override)
         {
-            IPCSocket::closePath(socketPath.c_str());
+            StreamIPCSocket::closePath(socketPath.c_str());
         }
 
         socket = ::socket(AF_UNIX, SOCK_STREAM, 0);
@@ -84,7 +84,7 @@ namespace kt
         }
     }
 
-    IPCSocket IPCServerSocket::accept(const long &timeout) const
+    StreamIPCSocket IPCServerSocket::accept(const long &timeout) const
     {
         if (timeout > 0)
         {
@@ -107,13 +107,13 @@ namespace kt
             throw kt::SocketException("Failed to accept connection. Socket is in an invalid state.");
         }
 
-        return kt::IPCSocket(temp, std::string(acceptedAddress.sun_path));
+        return kt::StreamIPCSocket(temp, std::string(acceptedAddress.sun_path));
     }
 
     void IPCServerSocket::close()
     {
         Socket::close(socket);
-        IPCSocket::closePath(socketPath);
+        StreamIPCSocket::closePath(socketPath);
         socket = kt::getInvalidSocketValue();
     }
 }

--- a/src/ipc/IPCServerSocket.h
+++ b/src/ipc/IPCServerSocket.h
@@ -2,6 +2,7 @@
 
 #include "../serversocket/ServerSocket.h"
 #include "StreamIPCSocket.h"
+#include "IPCSocket.h"
 
 #include <string>
 #include <optional>
@@ -9,7 +10,7 @@
 
 namespace kt
 {
-    class IPCServerSocket : public ServerSocket<StreamIPCSocket>
+    class IPCServerSocket : public ServerSocket<StreamIPCSocket>, public IPCSocket
     {
         private:
             SOCKET socket;

--- a/src/ipc/IPCServerSocket.h
+++ b/src/ipc/IPCServerSocket.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../serversocket/ServerSocket.h"
-#include "IPCSocket.h"
+#include "StreamIPCSocket.h"
 
 #include <string>
 #include <optional>
@@ -9,7 +9,7 @@
 
 namespace kt
 {
-    class IPCServerSocket : public ServerSocket<IPCSocket>
+    class IPCServerSocket : public ServerSocket<StreamIPCSocket>
     {
         private:
             SOCKET socket;
@@ -27,7 +27,7 @@ namespace kt
             SOCKET getSocket() const;
             std::string getSocketPath() const;
 
-            IPCSocket accept(const long& = 0) const override;
+            StreamIPCSocket accept(const long& = 0) const override;
 
             void close() override;
     };

--- a/src/ipc/IPCSocket.cpp
+++ b/src/ipc/IPCSocket.cpp
@@ -1,0 +1,9 @@
+#include "IPCSocket.h"
+
+namespace kt
+{
+    int IPCSocket::removeSocketPath(const std::string &socketPath)
+    {
+        return std::remove(socketPath.c_str());
+    }
+}

--- a/src/ipc/IPCSocket.h
+++ b/src/ipc/IPCSocket.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <string>
+
+namespace kt
+{
+    class IPCSocket
+    {
+        public:
+            int removeSocketPath(const std::string&);
+    };
+}

--- a/src/ipc/StreamIPCSocket.cpp
+++ b/src/ipc/StreamIPCSocket.cpp
@@ -47,11 +47,6 @@ namespace kt
         this->socket = getInvalidSocketValue();
     }
 
-    void StreamIPCSocket::closePath(const std::string &socketPath)
-    {
-        unlink(socketPath.c_str());
-    }
-
     void StreamIPCSocket::constructSocket()
     {
         sockaddr_un addr{};

--- a/src/ipc/StreamIPCSocket.cpp
+++ b/src/ipc/StreamIPCSocket.cpp
@@ -1,4 +1,4 @@
-#include "IPCSocket.h"
+#include "StreamIPCSocket.h"
 #include "../socket/Socket.h"
 #include "../socketexceptions/SocketError.h"
 #include "../socketexceptions/SocketException.hpp"
@@ -7,23 +7,23 @@
 
 namespace kt
 {
-    IPCSocket::IPCSocket(const std::string& socketPath) : socketPath(socketPath) 
+    StreamIPCSocket::StreamIPCSocket(const std::string& socketPath) : socketPath(socketPath) 
     {
         constructSocket();
     }
 
-    IPCSocket::IPCSocket(const SOCKET &socket, const std::string &socketPath) : socket(socket), socketPath(socketPath)
+    StreamIPCSocket::StreamIPCSocket(const SOCKET &socket, const std::string &socketPath) : socket(socket), socketPath(socketPath)
     {
 
     }
 
-    IPCSocket::IPCSocket(const IPCSocket &socket)
+    StreamIPCSocket::StreamIPCSocket(const StreamIPCSocket &socket)
     {
         this->socket = socket.socket;
         this->socketPath = socket.socketPath;
     }
 
-    IPCSocket &IPCSocket::operator=(const IPCSocket &socket)
+    StreamIPCSocket &StreamIPCSocket::operator=(const StreamIPCSocket &socket)
     {
         this->socket = socket.socket;
         this->socketPath = socket.socketPath;
@@ -31,28 +31,28 @@ namespace kt
         return *this;
     }
 
-    SOCKET IPCSocket::getSocket() const
+    SOCKET StreamIPCSocket::getSocket() const
     {
         return socket;
     }
 
-    std::string IPCSocket::getSocketPath() const
+    std::string StreamIPCSocket::getSocketPath() const
     {
         return socketPath;
     }
 
-    void IPCSocket::close()
+    void StreamIPCSocket::close()
     {
         Socket::close(socket);
         this->socket = getInvalidSocketValue();
     }
 
-    void IPCSocket::closePath(const std::string &socketPath)
+    void StreamIPCSocket::closePath(const std::string &socketPath)
     {
         unlink(socketPath.c_str());
     }
 
-    void IPCSocket::constructSocket()
+    void StreamIPCSocket::constructSocket()
     {
         sockaddr_un addr{};
         addr.sun_family = AF_UNIX;

--- a/src/ipc/StreamIPCSocket.h
+++ b/src/ipc/StreamIPCSocket.h
@@ -33,7 +33,7 @@ typedef int SOCKET;
 
 namespace kt
 {
-    class IPCSocket : public ConnectionOrientedSocket
+    class StreamIPCSocket : public ConnectionOrientedSocket
     {
         private:
             SOCKET socket;
@@ -41,12 +41,12 @@ namespace kt
 
             void constructSocket();
         public:
-            IPCSocket() = delete;
-            IPCSocket(const std::string&);
-            IPCSocket(const SOCKET&, const std::string&);
+            StreamIPCSocket() = delete;
+            StreamIPCSocket(const std::string&);
+            StreamIPCSocket(const SOCKET&, const std::string&);
 
-            IPCSocket(const IPCSocket&);
-			IPCSocket& operator=(const IPCSocket&);
+            StreamIPCSocket(const StreamIPCSocket&);
+			StreamIPCSocket& operator=(const StreamIPCSocket&);
 
             SOCKET getSocket() const override;
             std::string getSocketPath() const;

--- a/src/ipc/StreamIPCSocket.h
+++ b/src/ipc/StreamIPCSocket.h
@@ -52,7 +52,5 @@ namespace kt
             std::string getSocketPath() const;
 
             void close() override;
-
-            static void closePath(const std::string&);
     };
 } // namespace kt

--- a/src/socket/ConnectionLessSocket.h
+++ b/src/socket/ConnectionLessSocket.h
@@ -14,15 +14,13 @@ namespace kt
     class ConnectionLessSocket : public Socket
     {
         public:
-            virtual std::pair<int, T> bind(const std::optional<std::string>& = std::nullopt, const unsigned short& = 0, const std::optional<std::function<void(SOCKET&)>>& = std::nullopt) = 0;
+            virtual std::pair<int, T> bind(const std::optional<T>& = std::nullopt, const std::optional<std::function<void(SOCKET&)>>& = std::nullopt) = 0;
             virtual bool isBound() const = 0;
 
             virtual bool ready(const unsigned long = 100) const = 0;
 
             virtual int sendTo(const T&, const std::string&, const int& = 0) = 0;
             virtual int sendTo(const T&, const char*, const int&, const int& = 0) = 0;
-            virtual std::pair<int, T> sendTo(const std::string&, const unsigned short&, const std::string&, const int& = 0) = 0;
-            virtual std::pair<int, T> sendTo(const std::string&, const unsigned short&, const char*, const int&, const int& = 0) = 0;
             
             virtual std::pair<std::optional<std::string>, std::pair<int, T>> receiveFrom(const int&, const int& = 0) = 0;
             virtual std::pair<int, T> receiveFrom(char*, const int&, const int& = 0) const = 0;

--- a/src/socket/UDPSocket.cpp
+++ b/src/socket/UDPSocket.cpp
@@ -125,6 +125,11 @@ namespace kt
 
 	bool UDPSocket::ready(const unsigned long timeout) const
 	{
+		if (!isBound())
+		{
+			return false;
+		}
+
 		int result = this->pollSocket(this->receiveSocket, timeout);
 		// 0 indicates that there is no data
 		return result > 0;
@@ -190,7 +195,7 @@ namespace kt
 	std::pair<int, kt::SocketAddress> UDPSocket::receiveFrom(char* buffer, const int& receiveLength, const int& flags) const
 	{
 		kt::SocketAddress receiveAddress{};
-		if (!this->bound || receiveLength == 0)
+		if (!isBound() || receiveLength == 0)
 		{
 			return std::make_pair(-1, receiveAddress);
 		}

--- a/src/socket/UDPSocket.cpp
+++ b/src/socket/UDPSocket.cpp
@@ -43,11 +43,6 @@ namespace kt
 	 */
 	std::pair<int, kt::SocketAddress> kt::UDPSocket::bind(const kt::InternetProtocolVersion protocolVersion, const std::optional<std::string>& localHostname, const unsigned short& port, const std::optional<std::function<void(SOCKET&)>>& preBindSocketOperation)
 	{
-		if (this->isBound())
-		{
-			this->close();
-		}
-
 #ifdef _WIN32
 		WSADATA wsaData{};
 		if (int res = WSAStartup(MAKEWORD(2, 2), &wsaData); res != 0)
@@ -65,8 +60,20 @@ namespace kt
 		}
 
 		kt::SocketAddress firstAddress = resolvedAddresses.first.at(0);
-		this->protocolVersion = static_cast<kt::InternetProtocolVersion>(firstAddress.address.sa_family);
-		this->receiveSocket = socket(firstAddress.address.sa_family, hints.ai_socktype, hints.ai_protocol);
+		return bind(firstAddress, preBindSocketOperation);
+	}
+
+    std::pair<int, kt::SocketAddress> UDPSocket::bind(const std::optional<kt::SocketAddress> &addressOpt, const std::optional<std::function<void(SOCKET &)>> &preBindSocketOperation)
+    {
+		if (!addressOpt.has_value())
+		{
+			throw kt::BindingException("Failed to resolve bind address");
+		}
+		kt::SocketAddress address = addressOpt.value();
+
+		addrinfo hints = kt::createUdpHints(protocolVersion, AI_PASSIVE);
+        this->protocolVersion = static_cast<kt::InternetProtocolVersion>(address.address.sa_family);
+		this->receiveSocket = socket(address.address.sa_family, hints.ai_socktype, hints.ai_protocol);
 		if (kt::isInvalidSocket(this->receiveSocket))
 		{
 			throw kt::SocketException("Unable to construct socket from local host details. " + getErrorCode());
@@ -84,34 +91,27 @@ namespace kt
 
 #endif
 
+		if (this->isBound())
+		{
+			this->close();
+		}
+
 		if (preBindSocketOperation.has_value())
 		{
 			preBindSocketOperation.value()(this->receiveSocket);
 		}
 
-		int bindResult = ::bind(this->receiveSocket, &firstAddress.address, kt::getAddressLength(firstAddress));
+		int bindResult = ::bind(this->receiveSocket, &address.address, kt::getAddressLength(address));
 		this->bound = bindResult != -1;
 		if (!this->bound)
 		{
 			return std::make_pair(bindResult, kt::SocketAddress{});
 		}
 
-		if (port == 0)
-		{
-			this->initialiseListeningPortNumber();
-			firstAddress.ipv4.sin_port = htons(this->listeningPort.value());
-		}
-		else
-		{
-			this->listeningPort = std::make_optional(port);
-		}
+		this->initialiseListeningPortNumber();
+		address.ipv4.sin_port = htons(this->listeningPort.value());
 
-		return std::make_pair(bindResult, firstAddress);
-	}
-
-    std::pair<int, kt::SocketAddress> UDPSocket::bind(const std::optional<std::string> &localHostname, const unsigned short &port, const std::optional<std::function<void(SOCKET &)>> &preBindSocketOperation)
-    {
-        return bind(InternetProtocolVersion::Any, localHostname, port, preBindSocketOperation);
+		return std::make_pair(bindResult, address);
     }
 
     void UDPSocket::close()
@@ -153,22 +153,12 @@ namespace kt
 		return result;
 	}
 
-    std::pair<int, kt::SocketAddress> UDPSocket::sendTo(const std::string &hostname, const unsigned short &port, const std::string &message, const int &flags)
-    {
-        return this->sendTo(InternetProtocolVersion::Any, hostname, port, message, flags);
-    }
-
-    std::pair<int, kt::SocketAddress> UDPSocket::sendTo(const kt::InternetProtocolVersion protocolVersion, const std::string& hostname, const unsigned short& port, const std::string& message, const int& flags)
+    std::pair<int, kt::SocketAddress> UDPSocket::sendTo(const std::string& hostname, const unsigned short& port, const std::string& message, const int& flags, const kt::InternetProtocolVersion protocolVersion)
 	{
-		return this->sendTo(protocolVersion, hostname, port, &message[0], message.size(), flags);
+		return this->sendTo(hostname, port, &message[0], message.size(), flags, protocolVersion);
 	}
 
-    std::pair<int, kt::SocketAddress> UDPSocket::sendTo(const std::string &hostname, const unsigned short &port, const char *buffer, const int &bufferLength, const int &flags)
-    {
-        return this->sendTo(InternetProtocolVersion::Any, hostname, port, buffer, bufferLength, flags);
-    }
-
-    std::pair<int, kt::SocketAddress> UDPSocket::sendTo(const kt::InternetProtocolVersion protocolVersion, const std::string &hostname, const unsigned short &port, const char *buffer, const int &bufferLength, const int &flags)
+    std::pair<int, kt::SocketAddress> UDPSocket::sendTo(const std::string &hostname, const unsigned short &port, const char *buffer, const int &bufferLength, const int &flags, const kt::InternetProtocolVersion protocolVersion)
     {
 		addrinfo hints = kt::createUdpHints(protocolVersion);
 		std::pair<std::vector<kt::SocketAddress>, int> resolvedAddresses = kt::resolveToAddresses(hostname, port, hints);

--- a/src/socket/UDPSocket.h
+++ b/src/socket/UDPSocket.h
@@ -63,7 +63,7 @@ namespace kt
 
 		using ConnectionLessSocket::bind;
 		std::pair<int, kt::SocketAddress> bind(const kt::InternetProtocolVersion, const std::optional<std::string>& = std::nullopt, const unsigned short& = 0, const std::optional<std::function<void(SOCKET&)>>& = std::nullopt);
-		std::pair<int, kt::SocketAddress> bind(const std::optional<std::string>& = std::nullopt, const unsigned short& = 0, const std::optional<std::function<void(SOCKET&)>>& = std::nullopt) override;
+		std::pair<int, kt::SocketAddress> bind(const std::optional<kt::SocketAddress>& = std::nullopt, const std::optional<std::function<void(SOCKET&)>>& = std::nullopt) override;
 		bool isBound() const override;
 		
 		bool ready(const unsigned long = 100) const override;
@@ -71,11 +71,8 @@ namespace kt
 		using ConnectionLessSocket::sendTo;
 		int sendTo(const kt::SocketAddress&, const std::string&, const int& = 0) override;
 		int sendTo(const kt::SocketAddress&, const char*, const int&, const int& = 0) override;
-		std::pair<int, kt::SocketAddress> sendTo(const std::string&, const unsigned short&, const std::string&, const int& = 0) override;
-		std::pair<int, kt::SocketAddress> sendTo(const kt::InternetProtocolVersion, const std::string&, const unsigned short&, const std::string&, const int& = 0);
-
-		std::pair<int, kt::SocketAddress> sendTo(const std::string&, const unsigned short&, const char*, const int&, const int& = 0) override;
-		std::pair<int, kt::SocketAddress> sendTo(const kt::InternetProtocolVersion, const std::string&, const unsigned short&, const char*, const int&, const int& = 0);
+		std::pair<int, kt::SocketAddress> sendTo(const std::string&, const unsigned short&, const std::string&, const int& = 0, const kt::InternetProtocolVersion = kt::InternetProtocolVersion::Any);
+		std::pair<int, kt::SocketAddress> sendTo(const std::string&, const unsigned short&, const char*, const int&, const int& = 0, const kt::InternetProtocolVersion = kt::InternetProtocolVersion::Any);
 		
 		using ConnectionLessSocket::receiveFrom;
 		std::pair<std::optional<std::string>, std::pair<int, kt::SocketAddress>> receiveFrom(const int&, const int& = 0) override;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SOURCE
         socket/TCPSocketTest.cpp
         socket/UDPSocketTest.cpp
         ipc/StreamIPCSocketTest.cpp
+        ipc/DatagramIPCSocketTest.cpp
         ipc/IPCServerSocketTest.cpp
 
         address/SocketAddressTest.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,7 +21,7 @@ set(SOURCE
         serversocket/TCPServerSocketTest.cpp
         socket/TCPSocketTest.cpp
         socket/UDPSocketTest.cpp
-        ipc/IPCSocketTest.cpp
+        ipc/StreamIPCSocketTest.cpp
         ipc/IPCServerSocketTest.cpp
 
         address/SocketAddressTest.cpp

--- a/tests/ipc/DatagramIPCSocketTest.cpp
+++ b/tests/ipc/DatagramIPCSocketTest.cpp
@@ -1,0 +1,204 @@
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "../../src/ipc/DatagramIPCSocket.h"
+#include "../../src/socketexceptions/BindingException.hpp"
+
+const std::string SOCKET_PATH = "/tmp/DatagramIPCSocketTest.sock";
+
+namespace kt
+{
+#ifdef _WIN32
+
+TEST(DatagramIPCSocketTest, WindowsConstructorThrows)
+	{
+		ASSERT_THROW(DatagramIPCSocket socket, SocketException);
+	}
+
+#else
+    class DatagramIPCSocketTest : public ::testing::Test
+    {
+    protected:
+        DatagramIPCSocket socket;
+
+    protected:
+        DatagramIPCSocketTest() : socket() { }
+        void TearDown() override
+        {
+            this->socket.close();
+        }
+    };
+
+    /*
+     * Test the kt::DatagramIPCSocket constructors and exception handling for DatagramIPC. This covers the following scenarios:
+     * - Constructing a socket and ensuring its default values are set correctly
+     */
+    TEST_F(DatagramIPCSocketTest, DatagramIPCConstructors)
+    {
+        ASSERT_FALSE(socket.ready());
+        ASSERT_FALSE(socket.isBound());
+        ASSERT_EQ(std::nullopt, socket.getSocketPath());
+        ASSERT_TRUE(kt::isInvalidSocket(socket.getListeningSocket()));
+    }
+
+    TEST_F(DatagramIPCSocketTest, DatagramIPCCopyConstructors)
+    {
+        ASSERT_EQ(0, socket.bind(true, SOCKET_PATH).first);
+        DatagramIPCSocket copiedSocket(socket);
+
+        ASSERT_EQ(socket.getListeningSocket(), copiedSocket.getListeningSocket());
+        ASSERT_EQ(socket.isBound(), copiedSocket.isBound());
+        ASSERT_EQ(socket.getSocketPath(), copiedSocket.getSocketPath());
+
+        copiedSocket.close();
+    }
+
+    TEST_F(DatagramIPCSocketTest, DatagramIPCBindEmptyPath)
+    {
+        ASSERT_THROW(socket.bind(), BindingException);
+    }
+
+    /*
+     * Ensure that multiple calls to DatagramIPCSocket.bind() fails if another socket is already bound to that port.
+     */
+    TEST_F(DatagramIPCSocketTest, DatagramIPCBindAndBound_MultipleCalls)
+    {
+        ASSERT_FALSE(socket.isBound());
+        ASSERT_EQ(0, socket.bind(SOCKET_PATH).first);
+        ASSERT_TRUE(socket.isBound());
+
+        kt::DatagramIPCSocket newServer;
+        ASSERT_FALSE(newServer.isBound());
+        ASSERT_EQ(-1, newServer.bind(SOCKET_PATH).first);
+    }
+
+    /*
+     * Ensure that multiple calls to DatagramIPCSocket.bind() fails if another socket is already bound to that port.
+     */
+    TEST_F(DatagramIPCSocketTest, DatagramIPCBindAndBound_Override)
+    {
+        ASSERT_FALSE(socket.isBound());
+        ASSERT_EQ(0, socket.bind(SOCKET_PATH).first);
+        ASSERT_TRUE(socket.isBound());
+
+        kt::DatagramIPCSocket newServer;
+        ASSERT_FALSE(newServer.isBound());
+        ASSERT_EQ(0, newServer.bind(true, SOCKET_PATH).first);
+        ASSERT_TRUE(newServer.isBound());
+
+        newServer.close();
+    }
+
+    /*
+     * Test DatagramIPCSocket.sendTo() to ensure that it can send correctly to the listening socket.
+     */
+    TEST_F(DatagramIPCSocketTest, DatagramIPCSendTo)
+    {
+        ASSERT_EQ(0, socket.bind(SOCKET_PATH).first);
+
+        DatagramIPCSocket client;
+
+        ASSERT_FALSE(socket.ready());
+        const std::string testString = "test";
+        ASSERT_NE(std::nullopt, socket.getSocketPath());
+        ASSERT_EQ(client.sendTo(socket.getSocketPath().value(), testString), testString.size());
+
+        while(!socket.ready()) {}
+        ASSERT_TRUE(socket.ready());
+    }
+
+    /**
+     * Ensure that sending with an empty hostname failed to resolve the address and fail.
+     */
+    TEST_F(DatagramIPCSocketTest, TestEmptyHostname)
+    {
+        ASSERT_EQ(0, socket.bind(SOCKET_PATH).first);
+        
+        DatagramIPCSocket client;
+        ASSERT_FALSE(socket.ready());
+        const std::string message = "test";
+
+        ASSERT_EQ(-1, client.sendTo("", message, 0));
+        ASSERT_FALSE(socket.ready());        
+    }
+
+    /*
+     * Call DatagramIPCSocket.receiveFrom() to make sure the correct amount of data is read.
+     */
+    TEST_F(DatagramIPCSocketTest, DatagramIPCReceiveFrom)
+    {
+        ASSERT_EQ(0, socket.bind(SOCKET_PATH).first);
+        ASSERT_FALSE(socket.ready());
+
+        DatagramIPCSocket client;
+        const std::string testString = "test";
+        ASSERT_EQ(client.sendTo(SOCKET_PATH, testString), testString.size());
+
+        while(!socket.ready()) {}
+        ASSERT_TRUE(socket.ready());
+        std::pair<std::optional<std::string>, std::pair<int, std::string>> recieved = socket.receiveFrom(testString.size());
+        ASSERT_FALSE(socket.ready());
+        ASSERT_NE(std::nullopt, recieved.first);
+        ASSERT_EQ(testString.size(), recieved.second.first);
+        ASSERT_EQ(testString, recieved.first.value());
+        ASSERT_EQ(SOCKET_PATH, recieved.second.second);
+    }
+
+    /**
+     * Ensure that receiveAmount reads the specified amount even when more is available in the buffer.
+     * Also confirm that the remaining data is lost if not read.
+     */
+    TEST_F(DatagramIPCSocketTest, DatagramIPCReceiveAmount_NotEnoughRead)
+    {
+        ASSERT_EQ(0, socket.bind(SOCKET_PATH).first);
+        ASSERT_FALSE(socket.ready());
+
+        DatagramIPCSocket client;
+        const std::string testString = "test";
+        ASSERT_EQ(client.sendTo(SOCKET_PATH, testString), testString.size());
+
+        while(!socket.ready()) {}
+        ASSERT_TRUE(socket.ready());
+        std::pair<std::optional<std::string>, std::pair<int, std::string>> recieved = socket.receiveFrom(testString.size() - 1);
+        ASSERT_FALSE(socket.ready());
+        ASSERT_NE(std::nullopt, recieved.first);
+        ASSERT_EQ(testString.substr(0, testString.size() - 1), recieved.first.value());
+    }
+
+    /*
+     * Ensure that the receiveAmount reads the correct amount when less data is provided than expected.
+     */
+    TEST_F(DatagramIPCSocketTest, DatagramIPCReceiveAmount_TooMuchRead)
+    {
+        ASSERT_EQ(0, socket.bind(SOCKET_PATH).first);
+        ASSERT_FALSE(socket.ready());
+
+        DatagramIPCSocket client;
+        const std::string testString = "test";
+        ASSERT_EQ(client.sendTo(SOCKET_PATH, testString), testString.size());
+
+        while(!socket.ready()) {}
+        ASSERT_TRUE(socket.ready());
+        std::pair<std::optional<std::string>, std::pair<int, std::string>> recieved = socket.receiveFrom(testString.size() + 1);
+        ASSERT_FALSE(socket.ready());
+        ASSERT_NE(std::nullopt, recieved.first);
+        ASSERT_EQ(testString, recieved.first.value());
+    }
+
+    // Use the returned .bind() address to use as the socket address that is used to send a message
+    TEST_F(DatagramIPCSocketTest, SendToBoundAddress)
+    {
+        std::pair<int, std::string> bindResult = socket.bind(SOCKET_PATH);
+        ASSERT_EQ(0, bindResult.first);
+
+        DatagramIPCSocket client;
+        ASSERT_FALSE(socket.ready());
+        const std::string message = "SendToBoundAddress";
+        ASSERT_EQ(client.sendTo(bindResult.second, message), message.size());
+
+        while(!socket.ready()) {}
+        ASSERT_TRUE(socket.ready());
+    }
+#endif
+}

--- a/tests/ipc/IPCServerSocketTest.cpp
+++ b/tests/ipc/IPCServerSocketTest.cpp
@@ -49,9 +49,9 @@ namespace kt
         ASSERT_EQ(serverSocket.getSocket(), server2.getSocket());
         ASSERT_EQ(serverSocket.getSocketPath(), server2.getSocketPath());
 
-        IPCSocket client(SOCKET_PATH);
+        StreamIPCSocket client(SOCKET_PATH);
 
-        IPCSocket serverClient = server2.accept();
+        StreamIPCSocket serverClient = server2.accept();
         const std::string testString = "test";
 
         ASSERT_EQ(client.send(testString), testString.size());
@@ -80,7 +80,7 @@ namespace kt
     {
         std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
         EXPECT_THROW({
-            IPCSocket serverClient = serverSocket.accept(1 * 1000000);
+            StreamIPCSocket serverClient = serverSocket.accept(1 * 1000000);
         }, TimeoutException);
 
         std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();

--- a/tests/ipc/IPCServerSocketTest.cpp
+++ b/tests/ipc/IPCServerSocketTest.cpp
@@ -5,7 +5,7 @@
 #include "../../src/socketexceptions/BindingException.hpp"
 #include "../../src/socketexceptions/TimeoutException.hpp"
 
-const std::string SOCKET_PATH = "/tmp/IPCServerSocketTest";
+const std::string SOCKET_PATH = "/tmp/IPCServerSocketTest.sock";
 
 namespace kt
 {

--- a/tests/ipc/StreamIPCSocketTest.cpp
+++ b/tests/ipc/StreamIPCSocketTest.cpp
@@ -3,23 +3,23 @@
 #include <gtest/gtest.h>
 
 #include "../../src/ipc/IPCServerSocket.h"
-#include "../../src/ipc/IPCSocket.h"
+#include "../../src/ipc/StreamIPCSocket.h"
 
 #include "../../src/socketexceptions/SocketError.h"
 #include "../../src/socketexceptions/SocketException.hpp"
 
-const std::string SOCKET_PATH = "/tmp/IPCSocketTest.sock";
+const std::string SOCKET_PATH = "/tmp/StreamIPCSocketTest.sock";
 
 namespace kt
 {
-    class IPCSocketTest : public ::testing::Test
+    class StreamIPCSocketTest : public ::testing::Test
     {
     protected:
         IPCServerSocket serverSocket;
-        IPCSocket socket;
+        StreamIPCSocket socket;
 
     protected:
-        IPCSocketTest() : serverSocket(SOCKET_PATH), socket(SOCKET_PATH) { }
+        StreamIPCSocketTest() : serverSocket(SOCKET_PATH), socket(SOCKET_PATH) { }
         void TearDown() override
         {
             socket.close();
@@ -27,7 +27,7 @@ namespace kt
         }
     };
 
-    TEST_F(IPCSocketTest, IPCConstructor)
+    TEST_F(StreamIPCSocketTest, IPCConstructor)
     {
         ASSERT_TRUE(socket.connected());
         ASSERT_FALSE(socket.ready());
@@ -38,10 +38,10 @@ namespace kt
     /*
      * Ensure that a Socket created from the copy constructor is still able to send and receive from the copied socket.
      */
-    TEST_F(IPCSocketTest, IPCCopyConstructor)
+    TEST_F(StreamIPCSocketTest, IPCCopyConstructor)
     {
-        IPCSocket server = serverSocket.accept();
-        IPCSocket copiedSocket(socket);
+        StreamIPCSocket server = serverSocket.accept();
+        StreamIPCSocket copiedSocket(socket);
         
         ASSERT_EQ(socket.getSocket(), copiedSocket.getSocket());
         ASSERT_EQ(socket.getSocketPath(), copiedSocket.getSocketPath());
@@ -68,24 +68,24 @@ namespace kt
     /*
      * Ensure that a connected socket and accepted socket are correcly marked as connected.
      */
-    TEST_F(IPCSocketTest, IPCConnected)
+    TEST_F(StreamIPCSocketTest, IPCConnected)
     {
-        IPCSocket server = serverSocket.accept();
+        StreamIPCSocket server = serverSocket.accept();
         ASSERT_TRUE(socket.connected());
         ASSERT_TRUE(server.connected());
 
         server.close();
     }
 
-    TEST_F(IPCSocketTest, IPCUnlinkTest)
+    TEST_F(StreamIPCSocketTest, IPCUnlinkTest)
     {
         serverSocket.close();
-        ASSERT_THROW(IPCSocket client(SOCKET_PATH), SocketException);
+        ASSERT_THROW(StreamIPCSocket client(SOCKET_PATH), SocketException);
     }
 
-    TEST_F(IPCSocketTest, TCPReceiveAmount)
+    TEST_F(StreamIPCSocketTest, TCPReceiveAmount)
     {
-        IPCSocket server = serverSocket.accept();
+        StreamIPCSocket server = serverSocket.accept();
         const std::string testString = "test";
         ASSERT_FALSE(server.ready());
         ASSERT_EQ(socket.send(testString), testString.size());
@@ -96,9 +96,9 @@ namespace kt
         server.close();
     }
 
-    TEST_F(IPCSocketTest, TCPReceiveAll)
+    TEST_F(StreamIPCSocketTest, TCPReceiveAll)
     {
-        IPCSocket server = serverSocket.accept();
+        StreamIPCSocket server = serverSocket.accept();
         const std::string testString = "test";
         ASSERT_FALSE(server.ready());
         ASSERT_EQ(socket.send(testString + testString + testString), testString.size() * 3);
@@ -109,9 +109,9 @@ namespace kt
         server.close();
     }
 
-    TEST_F(IPCSocketTest, TCPReceiveToDelimiter)
+    TEST_F(StreamIPCSocketTest, TCPReceiveToDelimiter)
     {
-        IPCSocket server = serverSocket.accept();
+        StreamIPCSocket server = serverSocket.accept();
         const std::string testString = "test";
         char delimiter = '&';
         ASSERT_FALSE(socket.ready());
@@ -124,14 +124,14 @@ namespace kt
         server.close();
     }
 
-    TEST_F(IPCSocketTest, TCPReceiveToDelimiter_InvalidDelimiter)
+    TEST_F(StreamIPCSocketTest, TCPReceiveToDelimiter_InvalidDelimiter)
     {
         ASSERT_THROW(socket.receiveToDelimiter('\0'), SocketException);
     }
 
-    TEST_F(IPCSocketTest, TCPGet)
+    TEST_F(StreamIPCSocketTest, TCPGet)
     {
-        IPCSocket server = serverSocket.accept();
+        StreamIPCSocket server = serverSocket.accept();
         const std::string testString = "test";
         ASSERT_FALSE(socket.ready());
         ASSERT_EQ(server.send(testString), testString.size());
@@ -155,9 +155,9 @@ namespace kt
         server.close();
     }
 
-    TEST_F(IPCSocketTest, TCPClose)
+    TEST_F(StreamIPCSocketTest, TCPClose)
     {
-        IPCSocket server = serverSocket.accept();
+        StreamIPCSocket server = serverSocket.accept();
         ASSERT_TRUE(socket.connected());
         socket.close();
         ASSERT_FALSE(socket.connected());

--- a/tests/socket/ScenarioTest.cpp
+++ b/tests/socket/ScenarioTest.cpp
@@ -4,6 +4,7 @@
 #include "../../src/socket/UDPSocket.h"
 #include "../../src/serversocket/TCPServerSocket.h"
 #include "../../src/ipc/IPCServerSocket.h"
+#include "../../src/ipc/DatagramIPCSocket.h"
 
 namespace kt
 {
@@ -144,8 +145,8 @@ namespace kt
         socket.close();
     }
 
-    // The ipc README example
-    TEST(ScenarioTest, IpcExampleTest)
+    // The stream ipc README example
+    TEST(ScenarioTest, StreamIpcExampleTest)
     {
         const std::string ipcChannel = "/tmp/ipcExample.sock";
         // Create a new StreamIPCSocket
@@ -177,4 +178,32 @@ namespace kt
         server.close();
         serverSocket.close();
     }
+
+#ifndef _WIN32
+    // The datagram ipc README example
+    TEST(ScenarioTest, DatagramIpcExampleTest)
+    {
+        const std::string socketPath = "/tmp/my-socket.sock";
+
+        // The socket receiving data must first be bound
+        kt::DatagramIPCSocket socket;
+        socket.bind(socketPath);
+
+        kt::DatagramIPCSocket client;
+        const std::string testString = "UDP test string";
+        if (client.sendTo(socketPath, testString) == 0)
+        {
+            std::cout << "Failed to send." << std::endl;
+            return;
+        }
+
+        if (socket.ready())
+        {
+            std::pair<std::optional<std::string>, std::pair<int, std::string>> recieved = socket.receiveFrom(testString.size());
+            ASSERT_EQ(testString, recieved.first.value());
+        }
+
+        socket.close();
+    }
+#endif
 }

--- a/tests/socket/ScenarioTest.cpp
+++ b/tests/socket/ScenarioTest.cpp
@@ -148,14 +148,14 @@ namespace kt
     TEST(ScenarioTest, IpcExampleTest)
     {
         const std::string ipcChannel = "/tmp/ipcExample.sock";
-        // Create a new IPCSocket
+        // Create a new StreamIPCSocket
         kt::IPCServerSocket server(ipcChannel);
 
         // Create new IPC socket
-        kt::IPCSocket client(ipcChannel);
+        kt::StreamIPCSocket client(ipcChannel);
 
         // Accept the incoming connection at the server
-        kt::IPCSocket serverSocket = server.accept();
+        kt::StreamIPCSocket serverSocket = server.accept();
 
         // Send string with text before and after the delimiter
         const std::string testString = "IPC Delimiter Test";

--- a/tests/socket/ScenarioTest.cpp
+++ b/tests/socket/ScenarioTest.cpp
@@ -15,11 +15,11 @@ namespace kt
     TEST(ScenarioTest, UDPThenTCPBindSamePort)
     {
         kt::UDPSocket socket;
-        std::pair<int, kt::SocketAddress> bindResult = socket.bind();
+        std::pair<int, kt::SocketAddress> bindResult = socket.bind(kt::InternetProtocolVersion::IPV4);
         ASSERT_EQ(0, bindResult.first);
         ASSERT_NE(std::nullopt, socket.getListeningPort());
 
-        kt::TCPServerSocket server(std::nullopt, socket.getListeningPort().value());
+        kt::TCPServerSocket server(std::nullopt, socket.getListeningPort().value(), 20, kt::InternetProtocolVersion::IPV4);
 
         ASSERT_EQ(server.getPort(), socket.getListeningPort().value());
 
@@ -37,7 +37,7 @@ namespace kt
         kt::TCPServerSocket server;
 
         kt::UDPSocket socket;
-        std::pair<int, kt::SocketAddress> bindResult = socket.bind(std::nullopt, server.getPort());
+        std::pair<int, kt::SocketAddress> bindResult = socket.bind(kt::InternetProtocolVersion::Any, std::nullopt, server.getPort());
         ASSERT_EQ(0, bindResult.first);
         ASSERT_NE(std::nullopt, socket.getListeningPort());
 
@@ -62,11 +62,11 @@ namespace kt
         };
 
         kt::UDPSocket socket;
-        std::pair<int, kt::SocketAddress> bindResult = socket.bind(std::nullopt, 0, setReuseAddrOption);
+        std::pair<int, kt::SocketAddress> bindResult = socket.bind(kt::InternetProtocolVersion::Any, std::nullopt, 0, setReuseAddrOption);
         ASSERT_EQ(0, bindResult.first);
 
         kt::UDPSocket socket2;
-        bindResult = socket2.bind(std::nullopt, socket.getListeningPort().value(), setReuseAddrOption);
+        bindResult = socket2.bind(kt::InternetProtocolVersion::Any, std::nullopt, socket.getListeningPort().value(), setReuseAddrOption);
         ASSERT_EQ(0, bindResult.first);
 
         ASSERT_EQ(socket.getListeningPort().value(), socket2.getListeningPort().value());

--- a/tests/socket/UDPSocketTest.cpp
+++ b/tests/socket/UDPSocketTest.cpp
@@ -42,7 +42,7 @@ namespace kt
 
     TEST_F(UDPSocketTest, UDPCopyConstructors)
     {
-        ASSERT_EQ(0, socket.bind().first);
+        ASSERT_EQ(0, socket.bind(kt::InternetProtocolVersion::Any).first);
         UDPSocket copiedSocket(socket);
 
         ASSERT_EQ(socket.getListeningSocket(), copiedSocket.getListeningSocket());
@@ -62,14 +62,14 @@ namespace kt
     {
         ASSERT_FALSE(socket.isBound());
         ASSERT_EQ(kt::InternetProtocolVersion::Any, socket.getInternetProtocolVersion());
-        ASSERT_EQ(0, socket.bind().first);
+        ASSERT_EQ(0, socket.bind(kt::InternetProtocolVersion::Any).first);
         ASSERT_NE(kt::InternetProtocolVersion::Any, socket.getInternetProtocolVersion());
         ASSERT_TRUE(socket.isBound());
 
         kt::UDPSocket newServer;
         ASSERT_FALSE(newServer.isBound());
         ASSERT_NE(std::nullopt, socket.getListeningPort());
-        ASSERT_EQ(-1, newServer.bind(std::nullopt, socket.getListeningPort().value()).first);
+        ASSERT_EQ(-1, newServer.bind(socket.getInternetProtocolVersion(), std::nullopt, socket.getListeningPort().value()).first);
     }
 
     /*
@@ -78,7 +78,7 @@ namespace kt
     TEST_F(UDPSocketTest, UDPBind_WithoutSpecifiedPort)
     {
         ASSERT_FALSE(socket.isBound());
-        ASSERT_EQ(0, socket.bind(std::nullopt, 0).first);
+        ASSERT_EQ(0, socket.bind(kt::InternetProtocolVersion::Any).first);
         ASSERT_TRUE(socket.isBound());
         ASSERT_NE(0, socket.getListeningPort());
     }
@@ -88,7 +88,7 @@ namespace kt
      */
     TEST_F(UDPSocketTest, UDPSendTo)
     {
-        ASSERT_EQ(0, socket.bind().first);
+        ASSERT_EQ(0, socket.bind(kt::InternetProtocolVersion::Any).first);
 
         UDPSocket client;
 
@@ -105,7 +105,7 @@ namespace kt
      */
     TEST_F(UDPSocketTest, TestEmptyHostname)
     {
-        ASSERT_EQ(0, socket.bind().first);
+        ASSERT_EQ(0, socket.bind(kt::InternetProtocolVersion::Any).first);
         
         UDPSocket client;
         ASSERT_FALSE(socket.ready());
@@ -113,15 +113,15 @@ namespace kt
         
         // This test is used to document behaviour and differences between the OS' and how they resolve "" hostnames
 #ifdef _WIN32
-        ASSERT_EQ(client.sendTo(socket.getInternetProtocolVersion(), "", socket.getListeningPort().value(), message, 0).first, message.size());
+        ASSERT_EQ(client.sendTo("", socket.getListeningPort().value(), message, 0, socket.getInternetProtocolVersion()).first, message.size());
         // Looks like windows resolves an address, but it is not received
         ASSERT_FALSE(socket.ready());
 #elif __APPLE__
-        ASSERT_EQ(client.sendTo(socket.getInternetProtocolVersion(), "", socket.getListeningPort().value(), message, 0).first, message.size());
+        ASSERT_EQ(client.sendTo("", socket.getListeningPort().value(), message, 0, socket.getInternetProtocolVersion()).first, message.size());
         while(!socket.ready()) {}
         ASSERT_TRUE(socket.ready());
 #else // __linux__
-        ASSERT_EQ(client.sendTo(socket.getInternetProtocolVersion(), "", socket.getListeningPort().value(), message, 0).first, 0);
+        ASSERT_EQ(client.sendTo("", socket.getListeningPort().value(), message, 0, socket.getInternetProtocolVersion()).first, 0);
         ASSERT_FALSE(socket.ready());
 #endif
         
@@ -132,7 +132,7 @@ namespace kt
      */
     TEST_F(UDPSocketTest, UDPReceiveFrom)
     {
-        ASSERT_EQ(0, socket.bind().first);
+        ASSERT_EQ(0, socket.bind(kt::InternetProtocolVersion::Any).first);
         ASSERT_FALSE(socket.ready());
 
         UDPSocket client;
@@ -153,7 +153,7 @@ namespace kt
      */
     TEST_F(UDPSocketTest, UDPReceiveAmount_NotEnoughRead)
     {
-        ASSERT_EQ(0, socket.bind().first);
+        ASSERT_EQ(0, socket.bind(kt::InternetProtocolVersion::Any).first);
         ASSERT_FALSE(socket.ready());
 
         UDPSocket client;
@@ -173,7 +173,7 @@ namespace kt
      */
     TEST_F(UDPSocketTest, UDPReceiveAmount_TooMuchRead)
     {
-        ASSERT_EQ(0, socket.bind().first);
+        ASSERT_EQ(0, socket.bind(kt::InternetProtocolVersion::Any).first);
         ASSERT_FALSE(socket.ready());
 
         UDPSocket client;
@@ -193,7 +193,7 @@ namespace kt
      */
     TEST_F(UDPSocketTest, UDPSendToAddress)
     {
-        ASSERT_EQ(0, socket.bind().first);
+        ASSERT_EQ(0, socket.bind(kt::InternetProtocolVersion::Any).first);
         ASSERT_FALSE(socket.ready());
 
         UDPSocket client;


### PR DESCRIPTION
- Refactor IPCSocket as a base IPC socket class.
- Change existing "IPCSocket" class into a "StreamIPCSocket" class, since it uses `SOCK_STREAM`.
- Add new class "DatagramIPCSocket" that uses `AF_UNIX` with `SOCK_DGRAM`.
- Windows does not support the `AF_UNIX` with `SOCK_DGRAM` combination.